### PR TITLE
Add message count to users API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ python manage.py runserver
     "users": [
         {
             "username": "user_name",
-            "last_entry": "subject | message"
+            "last_entry": "subject | message",
+            "message_count": 5
         }
     ]
 }

--- a/guestbook/tests.py
+++ b/guestbook/tests.py
@@ -48,6 +48,7 @@ class GuestbookTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['users']), 1)
         self.assertEqual(response.data['users'][0]['username'], 'Test User')
+        self.assertEqual(response.data['users'][0]['message_count'], 1)
 
     def test_invalid_entry_creation(self):
         """

--- a/guestbook/views.py
+++ b/guestbook/views.py
@@ -93,7 +93,8 @@ class GuestbookViewSet(viewsets.ModelViewSet):
                 'users': [
                     {
                         'username': user's name,
-                        'last_entry': 'subject | message'
+                        'last_entry': 'subject | message',
+                        'message_count': total number of messages
                     },
                     ...
                 ]
@@ -123,6 +124,7 @@ class GuestbookViewSet(viewsets.ModelViewSet):
         return Response({
             'users': [{
                 'username': user['name'],
-                'last_entry': user['last_entry']
+                'last_entry': user['last_entry'],
+                'message_count': user['message_count']
             } for user in serializer.data]
         })


### PR DESCRIPTION
## Summary
- return `message_count` from `users_data`
- document `message_count` in `users_data` docstring and README
- test that the new key is present

## Testing
- `python manage.py test` *(fails: connection to Postgres refused)*

------
https://chatgpt.com/codex/tasks/task_e_686fb791e330832a8ab7f912f5dbe484